### PR TITLE
빌드시 views 폴더를 못찾는 이슈 수정

### DIFF
--- a/project3/src/server.ts
+++ b/project3/src/server.ts
@@ -3,4 +3,11 @@ import express from 'express'
 const PORT = 4000
 const app = express()
 
+app.set('view engine', 'pug')
+app.set('views', process.cwd() + '/src/views')
+app.use('/public', express.static(__dirname + '/public'))
+
+app.get('/', (req, res) => res.render('home'))
+app.get('/*', (req, res) => res.redirect('/'))
+
 app.listen(PORT, () => console.log(`Listening on http://localhost:${PORT}`))


### PR DESCRIPTION
- 배경
   개발환경에서는 제대로 동작하는데, 빌드 후 테스트를 해보면 빌드파일에서는 views 폴더를 찾지 못하는 이슈가 있었음
- 원인
   - views 폴더를 지정해주는 코드에서 명령어의 차이로 인해 발생하는 현상
   
   - `__dirname` : 해당 파일을 실행시키는 파일이 속한 현재 디렉터리
       - 개발 실행 : `/Users/jjanmo/Documents/MyProjects/Node/nodejs-tutorials/project3/src` 
         → 요값을 가져옴, 그래서 그 안에 있는 views 디렉터리에 접근가능
       - 빌드 후 실행 : `/Users/jjanmo/Documents/MyProjects/Node/nodejs-tutorials/project3/dist`
         → 요값을 가져옴, dist 안의 server.js를 실행하기 때문에. 그래서 그 안에는 views 디렉토리가 없기때문에 접근 불가 **에러**
   - `process.cwd()` : node 명령을 호출한 작업 디렉터리의 절대 경로
       - 개발 실행 : project3 안의 노드가 해당 명령을 실행하기때문에(server를 실행)  `/Users/jjanmo/Documents/MyProjects/Node/nodejs-tutorials/project3` 이런 절대경로를 얻을 수 있다.
       - 빌드 후 실행 : 이 역시 같은 노드가 있는 작업디렉터리이기때문에 같은 값을 갖게 된다.

- 결론
   - 개발환경이든 빌드환경이든 views는 같은 경로에 있기 때문에(변하지 않음)  **항상 같은 절대 경로를 반환해주는 명령어**를 사용해야함

---
- [참고1](https://inpa.tistory.com/entry/NODE-%F0%9F%93%9A-dirname-filename-processcwd-%EC%B0%A8%EC%9D%B4-%EC%A0%95%EB%A6%AC)
- 참고2 : **cwd** : current working directory 의 약어